### PR TITLE
Update AllTickets to also return an error

### DIFF
--- a/consensus/datong/consensus.go
+++ b/consensus/datong/consensus.go
@@ -251,7 +251,12 @@ func (dt *DaTong) Finalize(chain consensus.ChainReader, header *types.Header, st
 	if parent == nil {
 		return nil, consensus.ErrUnknownAncestor
 	}
-	ticketMap := state.AllTickets()
+	ticketMap, err := state.AllTickets()
+
+	if err != nil {
+		return nil, err
+	}
+
 	if len(ticketMap) == 1 {
 		return nil, errors.New("Next block don't have ticket, wait buy ticket")
 	}
@@ -474,6 +479,8 @@ func (dt *DaTong) Close() error {
 }
 
 func (dt *DaTong) getAllTickets(chain consensus.ChainReader, header *types.Header) (map[common.Hash]common.Ticket, error) {
+	var tickets map[common.Hash]common.Ticket
+
 	parent := chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
 	if parent == nil {
 		return nil, consensus.ErrUnknownAncestor
@@ -482,7 +489,14 @@ func (dt *DaTong) getAllTickets(chain consensus.ChainReader, header *types.Heade
 	if err != nil {
 		return nil, err
 	}
-	return statedb.AllTickets(), nil
+
+	tickets, err = statedb.AllTickets()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tickets, nil
 }
 
 type ticketSlice struct {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -18,6 +18,7 @@
 package state
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"sort"
@@ -873,6 +874,7 @@ func (db *StateDB) AllTickets() (map[common.Hash]common.Ticket, error) {
 		tickets = make(map[common.Hash]common.Ticket, 0)
 	} else {
 		if err := rlp.DecodeBytes(data, &tickets); err != nil {
+			log.Error("AllTickets failed to decode", "data", hex.EncodeToString(data))
 			return nil, err
 		}
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -777,7 +777,7 @@ func (db *StateDB) GetNotation(addr common.Address) uint64 {
 
 // AllNotation wacom
 func (db *StateDB) AllNotation() []common.Address {
-        //fmt.Printf("=========AllNotation=============\n")//caihaijun
+	//fmt.Printf("=========AllNotation=============\n")//caihaijun
 	db.rwlock.RLock()
 	defer db.rwlock.RUnlock()
 	data := db.GetData(common.FSNCallAddress, common.NotationKey)
@@ -792,7 +792,7 @@ func (db *StateDB) AllNotation() []common.Address {
 
 // GenNotation wacom
 func (db *StateDB) GenNotation(addr common.Address) error {
-        //fmt.Printf("=========GenNotation=============\n")//caihaijun
+	//fmt.Printf("=========GenNotation=============\n")//caihaijun
 	stateObject := db.GetOrNewStateObject(addr)
 	if stateObject != nil {
 		if n := db.GetNotation(addr); n != 0 {
@@ -823,7 +823,7 @@ func (db *StateDB) updateAssets(assets map[common.Hash]common.Asset) error {
 
 // AllAssets wacom
 func (db *StateDB) AllAssets() map[common.Hash]common.Asset {
-        //fmt.Printf("=========AllAssets=============\n")//caihaijun
+	//fmt.Printf("=========AllAssets=============\n")//caihaijun
 	db.rwlock.RLock()
 	defer db.rwlock.RUnlock()
 	data := db.GetData(common.FSNCallAddress, common.AssetKey)
@@ -838,7 +838,7 @@ func (db *StateDB) AllAssets() map[common.Hash]common.Asset {
 
 // GenAsset wacom
 func (db *StateDB) GenAsset(asset common.Asset) error {
-        //fmt.Printf("=========GenAsset=============\n")//caihaijun
+	//fmt.Printf("=========GenAsset=============\n")//caihaijun
 	assets := db.AllAssets()
 	if _, ok := assets[asset.ID]; ok {
 		return fmt.Errorf("%s Asset exists", asset.ID.String())
@@ -851,7 +851,7 @@ func (db *StateDB) GenAsset(asset common.Asset) error {
 
 // UpdateAsset wacom
 func (db *StateDB) UpdateAsset(asset common.Asset) error {
-        //fmt.Printf("=========UpdateAsset=============\n")//caihaijun
+	//fmt.Printf("=========UpdateAsset=============\n")//caihaijun
 	assets := db.AllAssets()
 	if _, ok := assets[asset.ID]; !ok {
 		return fmt.Errorf("%s Asset not found", asset.ID.String())
@@ -863,8 +863,8 @@ func (db *StateDB) UpdateAsset(asset common.Asset) error {
 }
 
 // AllTickets wacom
-func (db *StateDB) AllTickets() map[common.Hash]common.Ticket {
-        //fmt.Printf("=========AllTickets=============\n")//caihaijun
+func (db *StateDB) AllTickets() (map[common.Hash]common.Ticket, error) {
+	//fmt.Printf("=========AllTickets=============\n")//caihaijun
 	db.rwlock.RLock()
 	defer db.rwlock.RUnlock()
 	data := db.GetData(common.FSNCallAddress, common.TicketKey)
@@ -872,15 +872,22 @@ func (db *StateDB) AllTickets() map[common.Hash]common.Ticket {
 	if len(data) == 0 || data == nil {
 		tickets = make(map[common.Hash]common.Ticket, 0)
 	} else {
-		rlp.DecodeBytes(data, &tickets)
+		if err := rlp.DecodeBytes(data, &tickets); err != nil {
+			return nil, err
+		}
 	}
-	return tickets
+	return tickets, nil
 }
 
 // AddTicket wacom
 func (db *StateDB) AddTicket(ticket common.Ticket) error {
-        //fmt.Printf("=========AddTicket=============\n")//caihaijun
-	tickets := db.AllTickets()
+	//fmt.Printf("=========AddTicket=============\n")//caihaijun
+	tickets, err := db.AllTickets()
+
+	if err != nil {
+		return err
+	}
+
 	if _, ok := tickets[ticket.ID]; ok {
 		return fmt.Errorf("%s Ticket exists", ticket.ID.String())
 	}
@@ -892,8 +899,13 @@ func (db *StateDB) AddTicket(ticket common.Ticket) error {
 
 // RemoveTicket wacom
 func (db *StateDB) RemoveTicket(id common.Hash) error {
-        //fmt.Printf("=========RemoveTicket=============\n")//caihaijun
-	tickets := db.AllTickets()
+	//fmt.Printf("=========RemoveTicket=============\n")//caihaijun
+	tickets, err := db.AllTickets()
+
+	if err != nil {
+		return err
+	}
+
 	if _, ok := tickets[id]; !ok {
 		return fmt.Errorf("%s Ticket not found", id.String())
 	}
@@ -914,7 +926,7 @@ func (db *StateDB) updateTickets(tickets map[common.Hash]common.Ticket) error {
 
 // AllSwaps wacom
 func (db *StateDB) AllSwaps() map[common.Hash]common.Swap {
-        //fmt.Printf("=========AllSwaps=============\n")//caihaijun
+	//fmt.Printf("=========AllSwaps=============\n")//caihaijun
 	db.rwlock.RLock()
 	defer db.rwlock.RUnlock()
 	data := db.GetData(common.FSNCallAddress, common.SwapKey)
@@ -929,7 +941,7 @@ func (db *StateDB) AllSwaps() map[common.Hash]common.Swap {
 
 // AddSwap wacom
 func (db *StateDB) AddSwap(swap common.Swap) error {
-        //fmt.Printf("=========AddSwap=============\n")//caihaijun
+	//fmt.Printf("=========AddSwap=============\n")//caihaijun
 	swaps := db.AllSwaps()
 	if _, ok := swaps[swap.ID]; ok {
 		return fmt.Errorf("%s Ticket exists", swap.ID.String())
@@ -942,7 +954,7 @@ func (db *StateDB) AddSwap(swap common.Swap) error {
 
 // UpdateSwap wacom
 func (db *StateDB) UpdateSwap(swap common.Swap) error {
-        //fmt.Printf("=========UpdateSwap=============\n")//caihaijun
+	//fmt.Printf("=========UpdateSwap=============\n")//caihaijun
 	swaps := db.AllSwaps()
 	if _, ok := swaps[swap.ID]; !ok {
 		return fmt.Errorf("%s Swap not found", swap.ID.String())
@@ -955,7 +967,7 @@ func (db *StateDB) UpdateSwap(swap common.Swap) error {
 
 // RemoveSwap wacom
 func (db *StateDB) RemoveSwap(id common.Hash) error {
-        //fmt.Printf("=========RemoveSwap=============\n")//caihaijun
+	//fmt.Printf("=========RemoveSwap=============\n")//caihaijun
 	swaps := db.AllSwaps()
 	if _, ok := swaps[id]; !ok {
 		return fmt.Errorf("%s Swap not found", id.String())

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -352,7 +352,11 @@ func (st *StateTransition) handleFsnCall() error {
 		hash := st.evm.GetHash(height.Uint64() - 1)
 		id := crypto.Keccak256Hash(from[:], hash[:])
 
-		tickets := st.state.AllTickets()
+		tickets, err := st.state.AllTickets()
+
+		if err != nil {
+			return err
+		}
 
 		if _, ok := tickets[id]; ok {
 			return fmt.Errorf("one block just can buy one ticket")

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -71,7 +71,7 @@ type StateDB interface {
 	GenAsset(common.Asset) error
 	UpdateAsset(common.Asset) error
 
-	AllTickets() map[common.Hash]common.Ticket
+	AllTickets() (map[common.Hash]common.Ticket, error)
 	AddTicket(common.Ticket) error
 
 	AllAssets() map[common.Hash]common.Asset

--- a/internal/ethapi/api_fsn.go
+++ b/internal/ethapi/api_fsn.go
@@ -336,11 +336,18 @@ func (s *PublicFusionAPI) AllAssets(ctx context.Context, blockNr rpc.BlockNumber
 
 // AllTickets wacom
 func (s *PublicFusionAPI) AllTickets(ctx context.Context, blockNr rpc.BlockNumber) (map[common.Hash]common.Ticket, error) {
+	var tickets map[common.Hash]common.Ticket
+
 	state, _, err := s.b.StateAndHeaderByNumber(ctx, blockNr)
 	if state == nil || err != nil {
 		return nil, err
 	}
-	tickets := state.AllTickets()
+	tickets, err = state.AllTickets()
+
+	if err != nil {
+		return nil, err
+	}
+
 	return tickets, state.Error()
 }
 
@@ -363,12 +370,19 @@ func (s *PublicFusionAPI) TicketPrice(ctx context.Context) (string, error) {
 
 // AllTicketsByAddress wacom
 func (s *PublicFusionAPI) AllTicketsByAddress(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (map[common.Hash]common.Ticket, error) {
+	var tickets map[common.Hash]common.Ticket
+
 	state, _, err := s.b.StateAndHeaderByNumber(ctx, blockNr)
 	var ret = make(map[common.Hash]common.Ticket)
 	if state == nil || err != nil {
 		return nil, err
 	}
-	tickets := state.AllTickets()
+	tickets, err = state.AllTickets()
+
+	if err != nil {
+		return nil, err
+	}
+
 	for k, v := range tickets {
 		if v.Owner == address {
 			ret[k] = v


### PR DESCRIPTION
## Description

@bret-fusion 

I've updated the AllTickets method on the StateDB to return an error to be handled.

I believe this will fix the panics/crashes people are seeing with the confusing "fatal error: sync: Unlock of unlocked RWMutex" error message.

1. The stack trace shows the panic starts in map.go:551, which only happens if you are attempting to assign a value to a nil map.
2. The map assignment happens in the AddTicket method in statedb.go:889.
3. The tickets map can only be nil if the AllTickets method returns a nil map, this can happen if the rlp.DecodeBytes method has an error, which never gets handled.

This change will handle and return the error in the AddTicket method, avoiding the map assignment panic. I've added error logging to log the failing data.

![screen shot 2019-01-27 at 12 05 26 pm](https://user-images.githubusercontent.com/46535604/51806209-1784df00-222c-11e9-9da0-16b780420742.png)



## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.

