### PR TITLE
Update docker-entrypoint-miner-local-gtw.sh

### DIFF
--- a/docker-entrypoint-miner-local-gtw.sh
+++ b/docker-entrypoint-miner-local-gtw.sh
@@ -88,4 +88,4 @@ fi
 echo "flags: $cmd_options$cmd_options_local_gtw"
 
 # efsn  --unlock $unlock --ethstats 
-#efsn $cmd_options$cmd_options_local_gtw
+efsn $cmd_options$cmd_options_local_gtw

--- a/docker-entrypoint-miner-local-gtw.sh
+++ b/docker-entrypoint-miner-local-gtw.sh
@@ -5,11 +5,13 @@ DATA_DIR=$NODES_ROOT/data
 KEYSTORE_DIR=$DATA_DIR/keystore
 unlock=
 ethstats=
+autobt=
 
 display_usage() { 
     echo "Commands for Fusion efsn:" 
     echo -e "\n-e value    Reporting name of a ethstats service" 
     echo -e "\n-u value    Account to unlock" 
+    echo -e "\n-a value    Auto buy tickets (0 = maximum possible)" 
     } 
 
 while [ "$1" != "" ]; do
@@ -19,6 +21,9 @@ while [ "$1" != "" ]; do
                                 ;;
         -e | --ethstats )           shift
                                 ethstats=$1
+                                ;;
+        -a | --autobt )         shift
+                                autobt=$1
                                 ;;
         * )                     display_usage
                                 exit 1
@@ -76,7 +81,15 @@ if [ "$unlock" ]; then
     cmd_options=$cmd_options$unlock 
 fi
     
+if [ "$autobt" ]; then
+    # limit for auto buy tickets not implemented yet, so it's always 0 = unlimited for now
+    autobt=0
+    [ $autobt -gt 0 ] && autobt=" --autobt $autobt" || autobt=" --autobt"
+    cmd_options=$cmd_options$autobt 
+fi
+
 echo "flags: $cmd_options$cmd_options_local_gtw"
 
 # efsn  --unlock $unlock --ethstats 
 efsn $cmd_options$cmd_options_local_gtw
+

--- a/docker-entrypoint-miner-local-gtw.sh
+++ b/docker-entrypoint-miner-local-gtw.sh
@@ -5,13 +5,13 @@ DATA_DIR=$NODES_ROOT/data
 KEYSTORE_DIR=$DATA_DIR/keystore
 unlock=
 ethstats=
-autobt=
+autobt=false
 
 display_usage() { 
     echo "Commands for Fusion efsn:" 
     echo -e "\n-e value    Reporting name of a ethstats service" 
     echo -e "\n-u value    Account to unlock" 
-    echo -e "\n-a value    Auto buy tickets (0 = maximum possible)" 
+    echo -e "\n-a          Auto buy tickets" 
     } 
 
 while [ "$1" != "" ]; do
@@ -22,8 +22,7 @@ while [ "$1" != "" ]; do
         -e | --ethstats )           shift
                                 ethstats=$1
                                 ;;
-        -a | --autobt )         shift
-                                autobt=$1
+        -a | --autobt )         autobt=true
                                 ;;
         * )                     display_usage
                                 exit 1
@@ -81,15 +80,12 @@ if [ "$unlock" ]; then
     cmd_options=$cmd_options$unlock 
 fi
     
-if [ "$autobt" ]; then
-    # limit for auto buy tickets not implemented yet, so it's always 0 = unlimited for now
-    autobt=0
-    [ $autobt -gt 0 ] && autobt=" --autobt $autobt" || autobt=" --autobt"
+if [ "$autobt" = true ]; then
+    autobt=" --autobt"
     cmd_options=$cmd_options$autobt 
 fi
 
 echo "flags: $cmd_options$cmd_options_local_gtw"
 
 # efsn  --unlock $unlock --ethstats 
-efsn $cmd_options$cmd_options_local_gtw
-
+#efsn $cmd_options$cmd_options_local_gtw

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,11 +5,13 @@ DATA_DIR=$NODES_ROOT/data
 KEYSTORE_DIR=$DATA_DIR/keystore
 unlock=
 ethstats=
+autobt=false
 
 display_usage() { 
     echo "Commands for Fusion efsn:" 
     echo -e "\n-e value    Reporting name of a ethstats service" 
     echo -e "\n-u value    Account to unlock" 
+    echo -e "\n-a          Auto buy tickets" 
     } 
 
 while [ "$1" != "" ]; do
@@ -19,6 +21,8 @@ while [ "$1" != "" ]; do
                                 ;;
         -e | --ethstats )           shift
                                 ethstats=$1
+                                ;;
+        -a | --autobt )         autobt=true
                                 ;;
         * )                     display_usage
                                 exit 1
@@ -73,6 +77,11 @@ if [ "$unlock" ]; then
     cmd_options=$cmd_options$unlock 
 fi
     
+if [ "$autobt" = true ]; then
+    autobt=" --autobt"
+    cmd_options=$cmd_options$autobt 
+fi
+
 echo "final cmd_options updated to $cmd_options"
 
 


### PR DESCRIPTION
## Description

Proposal for a Docker entrypoint script that already allows passing an argument for auto buying tickets, while leaving open the option to limit the amount of tickets bought at a later stage

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
