### PR TITLE
Add check for minimum block time

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -24,9 +24,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	mapset "github.com/deckarep/golang-set"
 	"github.com/FusionFoundation/efsn/common"
 	"github.com/FusionFoundation/efsn/consensus"
+	"github.com/FusionFoundation/efsn/consensus/datong"
 	"github.com/FusionFoundation/efsn/consensus/misc"
 	"github.com/FusionFoundation/efsn/core"
 	"github.com/FusionFoundation/efsn/core/state"
@@ -35,6 +35,7 @@ import (
 	"github.com/FusionFoundation/efsn/event"
 	"github.com/FusionFoundation/efsn/log"
 	"github.com/FusionFoundation/efsn/params"
+	mapset "github.com/deckarep/golang-set"
 )
 
 const (
@@ -830,10 +831,12 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 
 	tstart := time.Now()
 	parent := w.chain.CurrentBlock()
+	minTime := new(big.Int).Add(parent.Time(), big.NewInt(int64(datong.MinBlockTime)))
 
-	if parent.Time().Cmp(new(big.Int).SetInt64(timestamp)) >= 0 {
-		timestamp = parent.Time().Int64() + 1
+	if minTime.Cmp(new(big.Int).SetInt64(timestamp)) > 0 {
+		timestamp = minTime.Int64()
 	}
+
 	// this will ensure we're not going off too far in the future
 	if now := time.Now().Unix(); timestamp > now+1 {
 		wait := time.Duration(timestamp-now) * time.Second


### PR DESCRIPTION
## Description

I added a check to the minimum block time in the consensus and updated the miner to not create blocks less than the minimum block time.

This will prevent an attack where a miner produces a series of blocks with 1 second times, which will create a chain with a higher total difficulty. This chain will be the canonical chain based on difficulty, but will fail consensus checks for 120+15 seconds, after the time expires it will become valid causing nodes to switch over to it.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

