### PR TITLE
Add docker option to run node on different port

### DIFF
--- a/docker-entrypoint-miner-local-gtw.sh
+++ b/docker-entrypoint-miner-local-gtw.sh
@@ -6,12 +6,14 @@ KEYSTORE_DIR=$DATA_DIR/keystore
 unlock=
 ethstats=
 autobt=false
+port=
 
 display_usage() { 
     echo "Commands for Fusion efsn:" 
     echo -e "\n-e value    Reporting name of a ethstats service" 
     echo -e "\n-u value    Account to unlock" 
     echo -e "\n-a          Auto buy tickets" 
+    echo -e "\n-p value    Network listen port" 
     } 
 
 while [ "$1" != "" ]; do
@@ -23,6 +25,9 @@ while [ "$1" != "" ]; do
                                 ethstats=$1
                                 ;;
         -a | --autobt )         autobt=true
+                                ;;
+        -p | --port )           shift
+                                port=$1
                                 ;;
         * )                     display_usage
                                 exit 1
@@ -83,6 +88,11 @@ fi
 if [ "$autobt" = true ]; then
     autobt=" --autobt"
     cmd_options=$cmd_options$autobt 
+fi
+
+if [ "$port" ]; then
+    port=" --port $port"
+    cmd_options=$cmd_options$port 
 fi
 
 echo "flags: $cmd_options$cmd_options_local_gtw"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,12 +6,14 @@ KEYSTORE_DIR=$DATA_DIR/keystore
 unlock=
 ethstats=
 autobt=false
+port=
 
 display_usage() { 
     echo "Commands for Fusion efsn:" 
     echo -e "\n-e value    Reporting name of a ethstats service" 
     echo -e "\n-u value    Account to unlock" 
     echo -e "\n-a          Auto buy tickets" 
+    echo -e "\n-p value    Network listen port" 
     } 
 
 while [ "$1" != "" ]; do
@@ -23,6 +25,9 @@ while [ "$1" != "" ]; do
                                 ethstats=$1
                                 ;;
         -a | --autobt )         autobt=true
+                                ;;
+        -p | --port )           shift
+                                port=$1
                                 ;;
         * )                     display_usage
                                 exit 1
@@ -82,8 +87,12 @@ if [ "$autobt" = true ]; then
     cmd_options=$cmd_options$autobt 
 fi
 
-echo "final cmd_options updated to $cmd_options"
+if [ "$port" ]; then
+    port=" --port $port"
+    cmd_options=$cmd_options$port 
+fi
 
+echo "final cmd_options updated to $cmd_options"
 
 # efsn  --unlock $unlock --ethstats 
 eval "efsn $cmd_options"


### PR DESCRIPTION
## Description

Running a node in a restricted environment or behind NAT requires the default port to be changed.
Only modifying the Docker publish option breaks peer discovery.
Added -p / --port options to the entrypoint script to get around this limitation.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` and tested the resulting file from ```dist``` folder in a browser.
- [ ] I have tested my code on the live network.
