### PR TITLE
Script depends on current working dir (pwd)

### DIFF
--- a/QuickNodeSetup/fsnNode.sh
+++ b/QuickNodeSetup/fsnNode.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 # FUSION Foundation
 
-# CWD_DIR="/home/$USER"
-CWD_DIR="$PWD"
+CWD_DIR="/home/$USER"
 
 pause(){
   read -p "Press [Enter] key to continue..." fackEnterKey


### PR DESCRIPTION
## Description

For some reason CWD_DIR="$PWD" was introduced with the update, which is
a) a breaking change
b) tries to create the node in whatever the current working dir is, even if it's /etc or /tmp
c) will change the script behaviour on subsequent calls depending on where the user is

Please review this change and unless I missed something revert to /home/$USER, $HOME or /var/lib since we're working as root anyway.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Breaking change (fix or feature that causes existing functionality to work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` and tested the resulting file from ```dist``` folder in a browser.
- [ ] I have tested my code on the live network.
