### PR TITLE
Added missing restart option to docker command

### DIFF
--- a/QuickNodeSetup/fsnNode.sh
+++ b/QuickNodeSetup/fsnNode.sh
@@ -213,7 +213,8 @@ createDockerContainer(){
     if [ "$nodetype" == "minerandlocalgateway2" ]; then
         sudo docker pull fusionnetwork/minerandlocalgateway2:latest
 
-        sudo docker create --name fusion -it -p 127.0.0.1:9000:9000 -p 127.0.0.1:9001:9001 -p 40408:40408 \
+        sudo docker create --name fusion -it --restart unless-stopped \
+	    -p 127.0.0.1:9000:9000 -p 127.0.0.1:9001:9001 -p 40408:40408 \
             -v "$CWD_DIR/fusion-node":/fusion-node \
             fusionnetwork/minerandlocalgateway2 \
             -u "$walletaddress" \


### PR DESCRIPTION
## Description

Arguments --restart unless-stopped were missing for minerandlocalgateway2

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` and tested the resulting file from ```dist``` folder in a browser.
- [ ] I have tested my code on the live network.
