### PR TITLE
restore TicketID to make difficulty calculation more randomly

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -408,7 +408,7 @@ const (
 	TimeLockFunc
 	// BuyTicketFunc wacom
 	BuyTicketFunc
-	// OldAssetValueChangeFunc wacom
+	// OldAssetValueChangeFunc wacom (deprecated)
 	OldAssetValueChangeFunc
 	// MakeSwapFunc wacom
 	MakeSwapFunc
@@ -484,14 +484,6 @@ type SendAssetParam struct {
 	AssetID Hash
 	To      Address
 	Value   *big.Int `json:",string"`
-}
-
-// AssetValueChangeParam wacom
-type AssetValueChangeParam struct {
-	AssetID Hash
-	To      Address
-	Value   *big.Int `json:",string"`
-	IsInc   bool
 }
 
 // AssetValueChangeExParam wacom
@@ -594,11 +586,6 @@ func (p *TimeLockParam) ToBytes() ([]byte, error) {
 
 // ToBytes wacom
 func (p *BuyTicketParam) ToBytes() ([]byte, error) {
-	return rlp.EncodeToBytes(p)
-}
-
-// ToBytes wacom
-func (p *AssetValueChangeParam) ToBytes() ([]byte, error) {
 	return rlp.EncodeToBytes(p)
 }
 
@@ -882,14 +869,6 @@ func (p *BuyTicketParam) Check(blockNumber *big.Int, timestamp uint64, adjust in
 		if end < timestamp+uint64(7*24*3600+adjust) {
 			return fmt.Errorf("BuyTicket end must be greater than latest block time + 1 week")
 		}
-	}
-	return nil
-}
-
-// Check wacom
-func (p *AssetValueChangeParam) Check(blockNumber *big.Int) error {
-	if p.Value == nil || p.Value.Cmp(Big0) <= 0 {
-		return fmt.Errorf("Value must be set and greater than 0")
 	}
 	return nil
 }

--- a/consensus/datong/api.go
+++ b/consensus/datong/api.go
@@ -12,6 +12,22 @@ type API struct {
 	chain consensus.ChainReader
 }
 
+func getSnapshotByHeader(header *types.Header) (*Snapshot, error) {
+	// Ensure we have an actually valid block and return its snapshot
+	if header == nil {
+		return nil, errUnknownBlock
+	}
+	snap, err := NewSnapshotFromHeader(header)
+	if err != nil {
+		if header.Number.Uint64() == 0 {
+			// return an empty snapshot
+			return newSnapshot().ToShow(), nil
+		}
+		return nil, err
+	}
+	return snap, nil
+}
+
 // GetSnapshot wacom
 func (api *API) GetSnapshot(number *rpc.BlockNumber) (*Snapshot, error) {
 	var header *types.Header
@@ -20,34 +36,11 @@ func (api *API) GetSnapshot(number *rpc.BlockNumber) (*Snapshot, error) {
 	} else {
 		header = api.chain.GetHeaderByNumber(uint64(number.Int64()))
 	}
-	// Ensure we have an actually valid block and return its snapshot
-	if header == nil {
-		return nil, errUnknownBlock
-	}
-	if  header.Number.Uint64() == 0  {
-		// return an empty snapshot
-		return  newSnapshot().ToShow() , nil
-	}
-	snap, err := newSnapshotWithData(getSnapDataByHeader(header))
-	if err != nil {
-		return nil, err
-	}
-	return snap.ToShow(), nil
+	return getSnapshotByHeader(header)
 }
 
 // GetSnapshotAtHash wacom
 func (api *API) GetSnapshotAtHash(hash common.Hash) (*Snapshot, error) {
 	header := api.chain.GetHeaderByHash(hash)
-	if header == nil {
-		return nil, errUnknownBlock
-	}
-	if  header.Number.Uint64() == 0  {
-		// return an empty snapshot
-		return  newSnapshot().ToShow() , nil
-	}
-	snap, err := newSnapshotWithData(getSnapDataByHeader(header))
-	if err != nil {
-		return nil, err
-	}
-	return snap.ToShow(), nil
+	return getSnapshotByHeader(header)
 }

--- a/consensus/datong/consensus.go
+++ b/consensus/datong/consensus.go
@@ -432,8 +432,6 @@ func (dt *DaTong) Seal(chain consensus.ChainReader, block *types.Block, results 
 
 		select {
 		case results <- block.WithSeal(header):
-			// One of the threads found a block, abort all others
-			stop = make(chan struct{})
 		default:
 			log.Warn("Sealing result is not read by miner", "sealhash", dt.SealHash(header))
 		}
@@ -706,7 +704,7 @@ func (dt *DaTong) calcBlockDifficulty(chain consensus.ChainReader, header *types
 		}
 	}
 	if !haveTicket {
-		return nil, nil, 0, nil, errors.New("Miner doesn't have ticket")
+		return nil, nil, 0, nil, fmt.Errorf("Miner doesn't have ticket at block height %v", parent.Number)
 	}
 	ticketsTotalAmount, numberOfticketOwners := parentTickets.NumberOfTicketsAndOwners()
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -32,6 +32,7 @@ import (
 	"github.com/FusionFoundation/efsn/core/rawdb"
 	"github.com/FusionFoundation/efsn/core/state"
 	"github.com/FusionFoundation/efsn/core/types"
+	"github.com/FusionFoundation/efsn/crypto"
 	"github.com/FusionFoundation/efsn/ethdb"
 	"github.com/FusionFoundation/efsn/log"
 	"github.com/FusionFoundation/efsn/params"
@@ -249,11 +250,15 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 
 	if g.TicketCreateInfo != nil {
 		for x := uint64(0); x < g.TicketCreateInfo.Count; x++ {
+			from := g.TicketCreateInfo.Owner
+			hash := crypto.Keccak256Hash(new(big.Int).SetUint64(x).Bytes())
+			id := crypto.Keccak256Hash(from[:], hash[:])
 			ticket := common.Ticket{
-				ID: common.TicketID(g.TicketCreateInfo.Owner, 0, x),
+				Owner: from,
 				TicketBody: common.TicketBody{
+					ID:         id,
 					Height:     0,
-					StartTime:  x,
+					StartTime:  g.TicketCreateInfo.Time,
 					ExpireTime: g.TicketCreateInfo.Time + 30*24*3600,
 				},
 			}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -28,6 +28,7 @@ import (
 	"github.com/FusionFoundation/efsn/common"
 	"github.com/FusionFoundation/efsn/common/hexutil"
 	"github.com/FusionFoundation/efsn/common/math"
+	"github.com/FusionFoundation/efsn/consensus/datong"
 	"github.com/FusionFoundation/efsn/core/rawdb"
 	"github.com/FusionFoundation/efsn/core/state"
 	"github.com/FusionFoundation/efsn/core/types"
@@ -259,6 +260,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 			statedb.AddTicket(ticket)
 		}
 		g.Mixhash, _ = statedb.UpdateTickets(common.Big0, g.Timestamp)
+		g.ExtraData = datong.GenerateGenesisExtraData(g.ExtraData, g.TicketCreateInfo.Count)
 	}
 
 	statedb.GenAsset(common.SystemAsset)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -485,24 +485,10 @@ func (st *StateTransition) handleFsnCall() error {
 		}
 		st.addLog(common.BuyTicketFunc, param.Data, common.NewKeyValue("TicketID", ticket.ID), common.NewKeyValue("TicketOwner", ticket.Owner))
 		return nil
-	case common.AssetValueChangeFunc, common.OldAssetValueChangeFunc:
+	case common.AssetValueChangeFunc:
 		outputCommandInfo("AssetValueChangeFunc", "from", st.msg.From())
-		var assetValueChangeParamEx common.AssetValueChangeExParam
-		if param.Func == common.OldAssetValueChangeFunc {
-			// convert old data to new format
-			assetValueChangeParam := common.AssetValueChangeParam{}
-			rlp.DecodeBytes(param.Data, &assetValueChangeParam)
-			assetValueChangeParamEx = common.AssetValueChangeExParam{
-				AssetID:     assetValueChangeParam.AssetID,
-				To:          assetValueChangeParam.To,
-				Value:       assetValueChangeParam.Value,
-				IsInc:       assetValueChangeParam.IsInc,
-				TransacData: "",
-			}
-		} else {
-			assetValueChangeParamEx = common.AssetValueChangeExParam{}
-			rlp.DecodeBytes(param.Data, &assetValueChangeParamEx)
-		}
+		assetValueChangeParamEx := common.AssetValueChangeExParam{}
+		rlp.DecodeBytes(param.Data, &assetValueChangeParamEx)
 
 		if err := assetValueChangeParamEx.Check(height); err != nil {
 			st.addLog(common.AssetValueChangeFunc, assetValueChangeParamEx, common.NewKeyValue("Error", err.Error()))

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -522,6 +522,12 @@ func (st *StateTransition) handleFsnCall() error {
 			return fmt.Errorf("must be change by owner")
 		}
 
+		if asset.Owner != assetValueChangeParamEx.To {
+			err := fmt.Errorf("to address must be owner")
+			st.addLog(common.AssetValueChangeFunc, assetValueChangeParamEx, common.NewKeyValue("Error", err.Error()))
+			return err
+		}
+
 		if assetValueChangeParamEx.IsInc {
 			st.state.AddBalance(assetValueChangeParamEx.To, assetValueChangeParamEx.AssetID, assetValueChangeParamEx.Value)
 			asset.Total = asset.Total.Add(asset.Total, assetValueChangeParamEx.Value)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1432,23 +1432,9 @@ func (pool *TxPool) validateFsnCallTx(tx *types.Transaction) error {
 			pool.removeTx(oldTxHash, true)
 		}
 
-	case common.AssetValueChangeFunc, common.OldAssetValueChangeFunc:
-		var assetValueChangeParamEx common.AssetValueChangeExParam
-		if param.Func == common.OldAssetValueChangeFunc {
-			// convert old data to new format
-			assetValueChangeParam := common.AssetValueChangeParam{}
-			rlp.DecodeBytes(param.Data, &assetValueChangeParam)
-			assetValueChangeParamEx = common.AssetValueChangeExParam{
-				AssetID:     assetValueChangeParam.AssetID,
-				To:          assetValueChangeParam.To,
-				Value:       assetValueChangeParam.Value,
-				IsInc:       assetValueChangeParam.IsInc,
-				TransacData: "",
-			}
-		} else {
-			assetValueChangeParamEx = common.AssetValueChangeExParam{}
-			rlp.DecodeBytes(param.Data, &assetValueChangeParamEx)
-		}
+	case common.AssetValueChangeFunc:
+		assetValueChangeParamEx := common.AssetValueChangeExParam{}
+		rlp.DecodeBytes(param.Data, &assetValueChangeParamEx)
 
 		if err := assetValueChangeParamEx.Check(height); err != nil {
 			return err

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1467,6 +1467,10 @@ func (pool *TxPool) validateFsnCallTx(tx *types.Transaction) error {
 			return fmt.Errorf("must be change by owner")
 		}
 
+		if asset.Owner != assetValueChangeParamEx.To {
+			return fmt.Errorf("to address must be owner")
+		}
+
 		if !assetValueChangeParamEx.IsInc {
 			if state.GetBalance(assetValueChangeParamEx.AssetID, assetValueChangeParamEx.To).Cmp(assetValueChangeParamEx.Value) < 0 {
 				return fmt.Errorf("not enough asset")

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1492,6 +1492,10 @@ func (pool *TxPool) validateFsnCallTx(tx *types.Transaction) error {
 			return fmt.Errorf("USAN's cannot be swapped")
 		}
 
+		if _, err := state.GetAsset(makeSwapParam.ToAssetID); err != nil {
+			return fmt.Errorf("ToAssetID asset %v not found", makeSwapParam.ToAssetID.String())
+		}
+
 		if makeSwapParam.FromAssetID == common.OwnerUSANAssetID {
 			notation := state.GetNotation(from)
 			if notation == 0 {
@@ -1641,6 +1645,16 @@ func (pool *TxPool) validateFsnCallTx(tx *types.Transaction) error {
 
 		if err := makeSwapParam.Check(height, timestamp); err != nil {
 			return err
+		}
+
+		for _, toAssetID := range makeSwapParam.ToAssetID {
+			if toAssetID == common.OwnerUSANAssetID {
+				return fmt.Errorf("USAN's cannot be multi swapped")
+			}
+
+			if _, err := state.GetAsset(toAssetID); err != nil {
+				return fmt.Errorf("ToAssetID asset %v not found", toAssetID.String())
+			}
 		}
 
 		ln := len(makeSwapParam.FromAssetID)

--- a/internal/ethapi/api_fsn.go
+++ b/internal/ethapi/api_fsn.go
@@ -789,15 +789,20 @@ type PrivateFusionAPI struct {
 var privateFusionAPI = &PrivateFusionAPI{}
 
 func AutoBuyTicket(account common.Address, passwd string) {
+	fbase := FusionBaseArgs{From: account}
+	args := BuyTicketArgs{FusionBaseArgs: fbase}
+
 	for {
-		select {
-		case <-common.AutoBuyTicketChan:
-			if privateFusionAPI.b.IsMining() {
-				fbase := FusionBaseArgs{From: account}
-				args := BuyTicketArgs{FusionBaseArgs: fbase}
-				privateFusionAPI.BuyTicket(nil, args, passwd)
+		<-common.AutoBuyTicketChan
+	COMSUMEALL:
+		for {
+			select {
+			case <-common.AutoBuyTicketChan:
+			default:
+				break COMSUMEALL
 			}
 		}
+		privateFusionAPI.BuyTicket(nil, args, passwd)
 	}
 }
 

--- a/internal/ethapi/api_fsn.go
+++ b/internal/ethapi/api_fsn.go
@@ -62,15 +62,6 @@ type BuyTicketArgs struct {
 	End   *hexutil.Uint64 `json:"end"`
 }
 
-// AssetValueChangeArgs wacom
-type AssetValueChangeArgs struct {
-	FusionBaseArgs
-	AssetID common.Hash    `json:"asset"`
-	To      common.Address `json:"to"`
-	Value   *hexutil.Big   `json:"value"`
-	IsInc   bool           `json:"isInc"`
-}
-
 type AssetValueChangeExArgs struct {
 	FusionBaseArgs
 	AssetID     common.Hash    `json:"asset"`
@@ -213,16 +204,6 @@ func (args *BuyTicketArgs) init(defStart uint64) {
 		args.End = new(hexutil.Uint64)
 		*(*uint64)(args.End) = uint64(*args.Start) + 30*24*3600
 	}
-}
-
-func (args *AssetValueChangeArgs) toData() ([]byte, error) {
-	param := common.AssetValueChangeParam{
-		AssetID: args.AssetID,
-		To:      args.To,
-		Value:   args.Value.ToInt(),
-		IsInc:   args.IsInc,
-	}
-	return param.ToBytes()
 }
 
 func (args *AssetValueChangeExArgs) toParam() *common.AssetValueChangeExParam {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -513,6 +513,12 @@ func (w *worker) resultLoop() {
 				}
 				continue
 			}
+			if w.unconfirmed.Has(block.ParentHash()) {
+				if common.DebugMode {
+					log.Info("ignore duplicate result", "number", block.NumberU64(), "parent", block.ParentHash())
+				}
+				continue
+			}
 
 			var (
 				sealhash = w.engine.SealHash(block.Header())
@@ -566,7 +572,7 @@ func (w *worker) resultLoop() {
 			w.chain.PostChainEvents(events, logs)
 
 			// Insert the block into the set of pending ones to resultLoop for confirmations
-			w.unconfirmed.Insert(block.NumberU64(), block.Hash())
+			w.unconfirmed.Insert(block.NumberU64(), block.Hash(), block.ParentHash())
 
 		case <-w.exitCh:
 			return


### PR DESCRIPTION
1. restore TicketID to make difficulty calculation more randomly
2. ignore duplicate block broadcasted base on same parent
3. check ToAssetID asset be existed in makeSwap
4. only asset owner can inc/dec and only his own asset