### PR TITLE
 Added option --disable-mining to the docker entrypoint scripts

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,31 +5,33 @@ DATA_DIR=$NODES_ROOT/data
 KEYSTORE_DIR=$DATA_DIR/keystore
 unlock=
 ethstats=
-autobt=false
+autobt="false"
+mining="true"
 
-display_usage() { 
-    echo "Commands for Fusion efsn:" 
-    echo -e "\n-e value    Reporting name of a ethstats service" 
-    echo -e "\n-u value    Account to unlock" 
-    echo -e "\n-a          Auto buy tickets" 
-    } 
+display_usage() {
+    echo "Commands for Fusion efsn:"
+    echo -e "-e value    Reporting name of a ethstats service"
+    echo -e "-u value    Account to unlock"
+    echo -e "-a          Auto buy tickets"
+    }
 
 while [ "$1" != "" ]; do
     case $1 in
         -u | --unlock )         shift
                                 unlock=$1
                                 ;;
-        -e | --ethstats )           shift
+        -e | --ethstats )       shift
                                 ethstats=$1
                                 ;;
-        -a | --autobt )         autobt=true
+        -a | --autobt )         autobt="true"
+                                ;;
+        --disable-mining )      mining="false"
                                 ;;
         * )                     display_usage
                                 exit 1
     esac
     shift
 done
-
 
 # create data folder if does not exit
 if [ ! -d "$DATA_DIR" ]; then
@@ -42,14 +44,17 @@ if [ ! -d "$KEYSTORE_DIR" ]; then
 fi
 
 # copy keystore file
-cp $NODES_ROOT/UTC* $KEYSTORE_DIR/
+cp $NODES_ROOT/UTC* $KEYSTORE_DIR/ 2>/dev/null
 
 # format command option
-cmd_options="--datadir $DATA_DIR --password /fusion-node/password.txt --mine"
+cmd_options="--datadir $DATA_DIR --password /fusion-node/password.txt"
+
+# cmd_options_local_gtw=' --identity 1 --rpc --ws --rpcaddr 127.0.0.1 --rpccorsdomain 127.0.0.1 --wsapi "eth,net,fsn,fsntx" --rpcapi "eth,net,fsn,fsntx" --wsaddr 127.0.0.1 --wsport 9001 --rpcport 9000'
+cmd_options_local_gtw=' --rpc --ws --rpcaddr 0.0.0.0 --rpccorsdomain 0.0.0.0  --wsapi="eth,net,fsn,fsntx" --rpcapi="eth,net,fsn,fsntx" --wsaddr 0.0.0.0 --wsport 9001 --wsorigins=* --rpcport 9000'
 
 if [ "$ethstats" ]; then
     ethstats=" --ethstats $ethstats:fsnMainnet@node.fusionnetwork.io"
-    cmd_options=$cmd_options$ethstats 
+    cmd_options=$cmd_options$ethstats
 fi
 
 if [ "$unlock" ]; then
@@ -71,19 +76,23 @@ if [ "$unlock" ]; then
     # if [ "$utc_json_address" = "$unlock" ]; then
     #     echo "$unlock is 'valid'"
     # fi
-    
+
     # echo "unlock set to: $unlock"
     unlock=" --unlock $unlock"
-    cmd_options=$cmd_options$unlock 
+    cmd_options=$cmd_options$unlock
 fi
-    
-if [ "$autobt" = true ]; then
+
+if [ "$autobt" = "true" ]; then
     autobt=" --autobt"
-    cmd_options=$cmd_options$autobt 
+    cmd_options=$cmd_options$autobt
 fi
 
-echo "final cmd_options updated to $cmd_options"
+if [ "$mining" = "true" ]; then
+    mining=" --mine"
+    cmd_options=$cmd_options$mining
+fi
 
+echo "efsn flags: $cmd_options$cmd_options_local_gtw"
 
-# efsn  --unlock $unlock --ethstats 
-eval "efsn $cmd_options"
+# efsn  --unlock $unlock --ethstats
+eval "efsn $cmd_options$cmd_options_local_gtw"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -49,8 +49,8 @@ cp $NODES_ROOT/UTC* $KEYSTORE_DIR/ 2>/dev/null
 # format command option
 cmd_options="--datadir $DATA_DIR --password /fusion-node/password.txt"
 
-# cmd_options_local_gtw=' --identity 1 --rpc --ws --rpcaddr 127.0.0.1 --rpccorsdomain 127.0.0.1 --wsapi "eth,net,fsn,fsntx" --rpcapi "eth,net,fsn,fsntx" --wsaddr 127.0.0.1 --wsport 9001 --rpcport 9000'
-cmd_options_local_gtw=' --rpc --ws --rpcaddr 0.0.0.0 --rpccorsdomain 0.0.0.0  --wsapi="eth,net,fsn,fsntx" --rpcapi="eth,net,fsn,fsntx" --wsaddr 0.0.0.0 --wsport 9001 --wsorigins=* --rpcport 9000'
+                                                                                                                                                                                                         
+                                                                                                                                                                                                   
 
 if [ "$ethstats" ]; then
     ethstats=" --ethstats $ethstats:fsnMainnet@node.fusionnetwork.io"
@@ -92,7 +92,7 @@ if [ "$mining" = "true" ]; then
     cmd_options=$cmd_options$mining
 fi
 
-echo "efsn flags: $cmd_options$cmd_options_local_gtw"
+echo "efsn flags: $cmd_options"
 
 # efsn  --unlock $unlock --ethstats
-eval "efsn $cmd_options$cmd_options_local_gtw"
+eval "efsn $cmd_options"


### PR DESCRIPTION
## Description

Added option --disable-mining and a few minor cosmetical changes to the docker entrypoint scripts.
To maximise node uptime it is desirable to have a fully synced secondary node in hot standby which does everything but mine. While the miner API module allows controlling the mining state while the node is running, it's preferable to have a safe way of launching the node with mining safely disabled independent of other settings like --autobt. To avoid confusion, breaking any existing configurations or accidentally disabling mining, the default is mining = true, also there's only a long option --disable-mining.

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` and tested the resulting file from ```dist``` folder in a browser.
- [x] I have tested my code on the live network.
