### PR TITLE
Fix fsn.yml: mount GP2 volume as dedicated /home partition

### DIFF
--- a/QuickNodeSetup/fsn.yml
+++ b/QuickNodeSetup/fsn.yml
@@ -136,7 +136,15 @@ Resources:
             --==BOUNDARY==
             Content-Type: text/x-shellscript; charset="us-ascii"
             #!/bin/bash
-            # Set any ECS agent configuration options
+            mkfs.ext4 /dev/xvdh
+            echo "/dev/xvdh  /home  ext4  defaults,discard,noatime,nodiratime  0 0" >> /etc/fstab
+            mv /home /home_old
+            mkdir /home
+            mount /home
+            # dotglob makes sure that hidden (dot) files are included
+            shopt -s dotglob
+            mv /home_old/* /home
+            rmdir /home_old
             mkdir -p /fusion-nodes/keystore
             # echo "password val" >> /fusion-nodes/password.txt
             # echo "keystore val" >> /fusion-nodes/keystore/UTC.txt


### PR DESCRIPTION
## Description

The AWS template (fsn.yml) creates an instance with an unused 300GB GP2 volume (/dev/xvdh). The node is running on the root partition (/dev/xvda1) with just ~6GB of free space though, which will lead to the catastrophic failure of every AWS node created based on the current instructions in the not so distant future, which in turn will cause the retreat of large amounts of tickets. Additionally, this currently causes unncessary costs of around $30/month.

Default system layout:

ubuntu@ip-172-31-14-6:~$ df -h | grep xvd
/dev/xvda1      7.7G  1.9G  5.9G  24% /

Using the volume requires additional setup:

root@ip-172-31-14-6:/home/ubuntu# sudo su root
root@ip-172-31-14-6:/home/ubuntu# mkfs.ext4 -q /dev/xvdh
root@ip-172-31-14-6:/home/ubuntu# mount /dev/xvdh /mnt/
root@ip-172-31-14-6:/home/ubuntu# df -h | grep xvd
/dev/xvda1      7.7G  1.9G  5.9G  24% /
/dev/xvdh       296G   63M  281G   1% /mnt

Note that 300GB is quite a lot already, this could be set to a lower value as the volume size can be increased while the system is running later if necessary.

The proposed change actually mounts the volume as dedicated /home partition while preserving the directory contents (otherwise it wouldn't be possible to login anymore as the default user's home directory, including its SSH key, would be missing).
It has been tested on live AWS instances according to the instructions in the official setup guide.

Note that this doesn't fix existing instances. I'll integrate a fix for that in my node manager.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` and tested the resulting file from ```dist``` folder in a browser.
- [x] I have tested my code on the live network.
