### PR TITLE
add testnet flag

### DIFF
--- a/Dockerfile.gtw
+++ b/Dockerfile.gtw
@@ -15,4 +15,9 @@ COPY --from=builder /efsn/build/bin/efsn /usr/local/bin/
 
 EXPOSE 9000 9000/udp 9001 9001/udp 40407 40407/udp 40408 40408/udp
 
-ENTRYPOINT ["efsn", "--identity", "1", "--datadir", "/fusion-node", "--rpc" , "--ws", "--rpcaddr" , "0.0.0.0", "--gasprice" , "0", "--rpccorsdomain" , "*", "--wsorigins", "*", "--wsapi", "eth,net,fsn,fsntx", "--rpcapi", "eth,net,fsn,fsntx", "--wsaddr", "0.0.0.0", "--wsport", "9001", "--rpcport", "9000"]
+COPY ./docker-entrypoint-gtw.sh /usr/local/bin
+
+RUN chmod a+x /usr/local/bin/docker-entrypoint-gtw.sh \
+  && ln -s /usr/local/bin/docker-entrypoint-gtw.sh / # Needed for backwards compatability
+
+ENTRYPOINT ["docker-entrypoint-gtw.sh"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Remember to:
 
 4. (Optional) Add flag "-a" or "--autobt" to enable ticket auto-buy.
 
+5. (Optional) Add flag "-tn" or "--testnet" to connect to the public testnet.
+
 `Note: The password file must be named password.txt and the keystore file name must start with UTC...`
 
 ## How to run a Gateway

--- a/README.md
+++ b/README.md
@@ -70,7 +70,13 @@ Install Docker first, e.g. on Ubuntu do `sudo apt-get install docker.io`
 
 ### Run a Gateway from the image
 
+1. Connect to mainnet
+
 `docker run -it -p 9000:9000 -p 9001:9001 -p 40408:40408 -v YOURDIRECTORY:/fusion-node fusionnetwork/gateway`
+
+2. Connect to testnet
+
+`docker run -it -p 9000:9000 -p 9001:9001 -p 40408:40408 -v YOURDIRECTORY:/fusion-node fusionnetwork/gateway -tn`
 
 ### Build your own Gateway image (optional)
 

--- a/docker-entrypoint-gtw.sh
+++ b/docker-entrypoint-gtw.sh
@@ -2,17 +2,12 @@
 NODES_ROOT=/fusion-node
 # NODES_ROOT=/Users/work/dev/tmp/fusion-node
 DATA_DIR=$NODES_ROOT/data
-KEYSTORE_DIR=$DATA_DIR/keystore
-unlock=
 ethstats=
 testnet=
-autobt=false
 
 display_usage() { 
-    echo "Commands for Fusion efsn:" 
+    echo "Commands for Fusion local gateway:" 
     echo -e "\n-e value    Reporting name of a ethstats service" 
-    echo -e "\n-u value    Account to unlock" 
-    echo -e "\n-a          Auto buy tickets" 
     echo -e "\n-tn         Connect to testnet" 
     } 
 
@@ -26,8 +21,6 @@ while [ "$1" != "" ]; do
                                 ;;
         -tn | --testnet )       testnet=true
                                 ;;
-        -a | --autobt )         autobt=true
-                                ;;
         * )                     display_usage
                                 exit 1
     esac
@@ -40,19 +33,11 @@ if [ ! -d "$DATA_DIR" ]; then
     mkdir $DATA_DIR
 fi
 
-# create keystore folder if does not exit
-if [ ! -d "$KEYSTORE_DIR" ]; then
-    mkdir $KEYSTORE_DIR
-fi
-
-# copy keystore file
-cp $NODES_ROOT/UTC* $KEYSTORE_DIR/
-
 # format command option
-cmd_options="--datadir $DATA_DIR --password /fusion-node/password.txt --mine"
+cmd_options="--datadir $DATA_DIR"
 
 # cmd_options_local_gtw=' --identity 1 --rpc --ws --rpcaddr 127.0.0.1 --rpccorsdomain 127.0.0.1 --wsapi "eth,net,fsn,fsntx" --rpcapi "eth,net,fsn,fsntx" --wsaddr 127.0.0.1 --wsport 9001 --rpcport 9000'
-cmd_options_local_gtw=' --rpc --ws --rpcaddr 0.0.0.0 --rpccorsdomain 0.0.0.0  --wsapi="eth,net,fsn,fsntx" --rpcapi="eth,net,fsn,fsntx" --wsaddr 0.0.0.0 --wsport 9001 --wsorigins=* --rpcport 9000'
+cmd_options_local_gtw=' --identity 1 --rpc --ws --rpcaddr 0.0.0.0 --rpccorsdomain "*" --wsorigins "*" --wsapi "eth,net,fsn,fsntx" --rpcapi "eth,net,fsn,fsntx" --wsaddr 0.0.0.0 --wsport 9001 --rpcport 9000'
 
 if [ "$testnet" ]; then
     testnet=" --testnet"
@@ -67,36 +52,6 @@ if [ "$ethstats" ]; then
         ethstats=" --ethstats $ethstats:fsnMainnet@node.fusionnetwork.io"
         cmd_options=$cmd_options$ethstats
     fi
-fi
-
-if [ "$unlock" ]; then
-
-    # pattern=$KEYSTORE_DIR/UTC*
-    # echo "pater: $pattern"
-
-    # keystore_files=($pattern)
-
-    # # for f in "${keystore_files[@]}"; do
-    # #     echo "file: $f"
-    # # done
-
-    # echo "file: ${keystore_files[0]}"
-
-    # utc_json_address="$(cat < ${keystore_files[0]} | jq -r '.address')"
-    # echo "utc_json_address: $utc_json_address"
-
-    # if [ "$utc_json_address" = "$unlock" ]; then
-    #     echo "$unlock is 'valid'"
-    # fi
-    
-    # echo "unlock set to: $unlock"
-    unlock=" --unlock $unlock"
-    cmd_options=$cmd_options$unlock 
-fi
-    
-if [ "$autobt" = true ]; then
-    autobt=" --autobt"
-    cmd_options=$cmd_options$autobt 
 fi
 
 echo "flags: $cmd_options$cmd_options_local_gtw"

--- a/docker-entrypoint-gtw.sh
+++ b/docker-entrypoint-gtw.sh
@@ -13,9 +13,6 @@ display_usage() {
 
 while [ "$1" != "" ]; do
     case $1 in
-        -u | --unlock )         shift
-                                unlock=$1
-                                ;;
         -e | --ethstats )       shift
                                 ethstats=$1
                                 ;;

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,14 +5,16 @@ DATA_DIR=$NODES_ROOT/data
 KEYSTORE_DIR=$DATA_DIR/keystore
 unlock=
 ethstats=
-autobt="false"
-mining="true"
+testnet=
+autobt=false
+mining=true
 
 display_usage() {
     echo "Commands for Fusion efsn:"
     echo -e "-e value    Reporting name of a ethstats service"
     echo -e "-u value    Account to unlock"
     echo -e "-a          Auto buy tickets"
+    echo -e "-tn         Connect to testnet"
     }
 
 while [ "$1" != "" ]; do
@@ -23,9 +25,11 @@ while [ "$1" != "" ]; do
         -e | --ethstats )       shift
                                 ethstats=$1
                                 ;;
-        -a | --autobt )         autobt="true"
+        -tn | --testnet )       testnet=true
                                 ;;
-        --disable-mining )      mining="false"
+        -a | --autobt )         autobt=true
+                                ;;
+        --disable-mining )      mining=false
                                 ;;
         * )                     display_usage
                                 exit 1
@@ -49,12 +53,19 @@ cp $NODES_ROOT/UTC* $KEYSTORE_DIR/ 2>/dev/null
 # format command option
 cmd_options="--datadir $DATA_DIR --password /fusion-node/password.txt"
 
-                                                                                                                                                                                                         
+if [ "$testnet" ]; then
+    testnet=" --testnet"
+    cmd_options=$cmd_options$testnet
+fi                                                                                                                                                                                                         
                                                                                                                                                                                                    
-
 if [ "$ethstats" ]; then
-    ethstats=" --ethstats $ethstats:fsnMainnet@node.fusionnetwork.io"
-    cmd_options=$cmd_options$ethstats
+    if [ "$testnet" ]; then
+        ethstats=" --ethstats $ethstats:devFusioInfo2019142@devnodestats.fusionnetwork.io"
+        cmd_options=$cmd_options$ethstats
+    else 
+        ethstats=" --ethstats $ethstats:fsnMainnet@node.fusionnetwork.io"
+        cmd_options=$cmd_options$ethstats
+    fi
 fi
 
 if [ "$unlock" ]; then
@@ -82,12 +93,12 @@ if [ "$unlock" ]; then
     cmd_options=$cmd_options$unlock
 fi
 
-if [ "$autobt" = "true" ]; then
+if [ "$autobt" = true ]; then
     autobt=" --autobt"
     cmd_options=$cmd_options$autobt
 fi
 
-if [ "$mining" = "true" ]; then
+if [ "$mining" = true ]; then
     mining=" --mine"
     cmd_options=$cmd_options$mining
 fi


### PR DESCRIPTION
## Description

Added flag -tn to docker images for easy access to the public testnet. Once merged I will rebuild the docker images to include this functionality.

## Examples

1. efsn image

`docker run -it -p 40408:40408 -v YOURDIRECTORY:/fusion-node fusionnetwork/efsn -u <account to unlock> -e MyFusionMiner -tn`

2. gateway image

`docker run -it -p 9000:9000 -p 9001:9001 -p 40408:40408 -v YOURDIRECTORY:/fusion-node fusionnetwork/gateway -tn`

3. miner and gateway image

`docker run -it -p 127.0.0.1:9000:9000 -p 127.0.0.1:9001:9001 -p 40408:40408 -v YOURDIRECTORY:/fusion-node fusionnetwork/minerandlocalgateway -u <account to unlock> -e MyFusionMinerAndLocalGateway -tn`



