### PR TITLE
Fixed broken signal handling in entrypoint scripts

### DIFF
--- a/docker-entrypoint-gtw.sh
+++ b/docker-entrypoint-gtw.sh
@@ -53,4 +53,4 @@ fi
 echo "flags: $cmd_options$cmd_options_local_gtw"
 
 # efsn  --unlock $unlock --ethstats
-eval "efsn $cmd_options$cmd_options_local_gtw"
+exec efsn $cmd_options$cmd_options_local_gtw

--- a/docker-entrypoint-miner-local-gtw.sh
+++ b/docker-entrypoint-miner-local-gtw.sh
@@ -109,4 +109,4 @@ fi
 echo "efsn flags: $cmd_options$cmd_options_local_gtw"
 
 # efsn  --unlock $unlock --ethstats
-eval "efsn $cmd_options$cmd_options_local_gtw"
+exec efsn $cmd_options$cmd_options_local_gtw

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -105,4 +105,4 @@ fi
 echo "efsn flags: $cmd_options"
 
 # efsn  --unlock $unlock --ethstats
-eval "efsn $cmd_options"
+exec efsn $cmd_options


### PR DESCRIPTION
## Description

When a container is stopped, a SIGTERM signal is sent to the root process (1), which is the entrypoint script in this case, instead of efsn which is running in a subshell. The entrypoint scripts use `eval` to construct a command line, which seems unnecessary here. Using `exec` instead causes the parent process to be replaced with the exec'ed command. Thus efsn becomes the root process, properly receiving the SIGTERM signal.

This fixes two issues:
1) the container doesn't have to wait for a timeout (default 10s) until it sends a SIGKILL signal to forcefully end any processes.
2) efsn has time to properly flush its caches to disk and close the database, avoiding unnecessary resyncs.

I've seen occasional resyncs of several thousand blocks after unclean shutdowns, which might lead to ticket loss even during planned maintenance like a node update or configuration change.

Before change:

![image](https://user-images.githubusercontent.com/11341130/88534535-936e0c00-d008-11ea-96dc-b28237820c3f.png)

After change:

![image](https://user-images.githubusercontent.com/11341130/88534548-9963ed00-d008-11ea-97c3-28d8f79a2ab4.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested my code on the live network.
